### PR TITLE
Fix bl808-firmware dependencies

### DIFF
--- a/recipes-bsp/bl808-firmware/bl808-firmware_1.0.0.bb
+++ b/recipes-bsp/bl808-firmware/bl808-firmware_1.0.0.bb
@@ -12,8 +12,7 @@ PR = "r1"
 
 inherit deploy python3native
 
-DEPENDS = "u-boot opensbi python3-native lz4-native"
-RDEPENDS:${PN} += " python3-core lz4 u-boot opensbi"
+DEPENDS = "u-boot opensbi lz4-native"
 
 do_install() {
     install -d ${D}${bindir}

--- a/recipes-bsp/bl808-firmware/bl808-firmware_1.0.0.bb
+++ b/recipes-bsp/bl808-firmware/bl808-firmware_1.0.0.bb
@@ -12,7 +12,8 @@ PR = "r1"
 
 inherit deploy python3native
 
-DEPENDS = "u-boot opensbi lz4-native"
+DEPENDS = "lz4-native"
+do_install[depends] += "opensbi:do_deploy u-boot:do_deploy"
 
 do_install() {
     install -d ${D}${bindir}

--- a/recipes-bsp/bl808-firmware/files/mergebin.py
+++ b/recipes-bsp/bl808-firmware/files/mergebin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Description: Merge the Kernel, DTB, and OpenSBI into a single binary
 # From @BBBSnowball 
 import struct


### PR DESCRIPTION
Hello, I've finally gotten around to starting to use my new 0x64 and I ran into some issues when attempting to build. I use `BB_NUMBER_THREADS = "20"`, so I think that made me more likely to run into some race conditions.

This PR includes fixes for two problems I encountered on my build. Let me know if you think anything should be different.

Thanks for the meta layers! Can't wait to get the 0x64 into a state where I can use it for Zigbee automation.

## Fix for python3-native dependency and unnecessary RDEPENDS.

When I attempted to build, I noticed that it was compiling Python 3 for bl808-firmware. This was unnecessary since python3 is installed on the system and is included in the native-path by python3-native. Upon investigation, I found the Python core dependency in RDEPENDS. Since the bl808-firmware task does not install programs that are used within the Linux runtime on the target, there are no need for runtime dependencies. This change removes the RDEPENDS and removes python3-native from DEPENDS because it is already included within the python3native.bbclass. Also, I've changed the shebang line at the top of "mergebin.py" to use the python3 in PATH from the bitbake native-path. This ensures that the task runs using the python3 given by bitbake if it's ever different than the system python3.

## Fix for bl808-firmware do_install dependencies

When using DEPENDS, bl808-firmware.do_prepare_recipe_sysroot requires opensbi.do_populate_sysroot. do_populate_sysroot can happen before do_deploy, so do_deploy for opensbi does not always complete before do_install in bl808-firmware is attempted.

A simplified dependency graph from "task-depends.dot" as it is now is:

bl808-firmware.do_install -> do_compile -> do_configure -> do_prepare_recipe_sysroot -> :
 * opensbi.do_populate_sysroot -> opensbi.do_install (does not depend on on_deploy)
 * u-boot.do_populate_sysroot -> u-boot.do_install (does not depend on on_deploy

This proposed fix explicitly states that do_install for bl808-firmware depends on do_deploy for both u-boot and opensbi. The graph after this fix looks like:

"bl808-firmware.do_install" -> "opensbi.do_deploy"
"bl808-firmware.do_install" -> "u-boot.do_deploy"

This ensures that the required blobs are in the deploy directory before they are copied in do_install.